### PR TITLE
add an option to define the locale for the BigDecimal Parser annotation

### DIFF
--- a/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/annotation/ParseBigDecimal.java
+++ b/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/annotation/ParseBigDecimal.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,15 +15,14 @@
  */
 package com.github.dmn1k.supercsv.io.declarative.annotation;
 
+import com.github.dmn1k.supercsv.io.declarative.CellProcessorAnnotationDescriptor;
+import com.github.dmn1k.supercsv.io.declarative.ProcessorOrder;
+import com.github.dmn1k.supercsv.io.declarative.StandardCsvContexts;
+import com.github.dmn1k.supercsv.io.declarative.provider.ParseBigDecimalCellProcessorProvider;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import com.github.dmn1k.supercsv.io.declarative.ProcessorOrder;
-import com.github.dmn1k.supercsv.io.declarative.StandardCsvContexts;
-import com.github.dmn1k.supercsv.io.declarative.provider.ParseBigDecimalCellProcessorProvider;
-import com.github.dmn1k.supercsv.io.declarative.CellProcessorAnnotationDescriptor;
 
 /**
  * Annotation for the {@link org.supercsv.cellprocessor.ParseBigDecimal}-cell processor
@@ -37,4 +36,8 @@ import com.github.dmn1k.supercsv.io.declarative.CellProcessorAnnotationDescripto
 public @interface ParseBigDecimal {
 
     int order() default ProcessorOrder.UNDEFINED;
+    /**
+     * Locale definition as found in {@link java.util.Locale#forLanguageTag}.
+     */
+    String locale();
 }

--- a/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/provider/ParseBigDecimalCellProcessorProvider.java
+++ b/super-csv-declarative/src/main/java/com/github/dmn1k/supercsv/io/declarative/provider/ParseBigDecimalCellProcessorProvider.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,13 @@
  */
 package com.github.dmn1k.supercsv.io.declarative.provider;
 
+import com.github.dmn1k.supercsv.io.declarative.annotation.ParseBigDecimal;
 import com.github.dmn1k.supercsv.model.CellProcessorFactory;
 import com.github.dmn1k.supercsv.model.DeclarativeCellProcessorProvider;
 import com.github.dmn1k.supercsv.model.ProcessingMetadata;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import org.supercsv.cellprocessor.ift.CellProcessor;
-import com.github.dmn1k.supercsv.io.declarative.annotation.ParseBigDecimal;
 
 /**
  * CellProcessorProvider for {@link ParseBigDecimal}
@@ -43,7 +45,13 @@ public class ParseBigDecimalCellProcessorProvider implements DeclarativeCellProc
 
             @Override
             public CellProcessor create(CellProcessor next) {
-                return new org.supercsv.cellprocessor.ParseBigDecimal(next);
+                if (null == metadata.getAnnotation().locale()) {
+                    return new org.supercsv.cellprocessor.ParseBigDecimal(next);
+                } else {
+                    final Locale locale = Locale.forLanguageTag(metadata.getAnnotation().locale());
+                    final DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance(locale);
+                    return new org.supercsv.cellprocessor.ParseBigDecimal(dfs, next);
+                }
             }
         };
     }


### PR DESCRIPTION
This allows to parse values that are created in a non standard locale format like german which uses a colon as the decimal separator.